### PR TITLE
Update foreword to match new styles in Leonid Andreyev

### DIFF
--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -5,6 +5,11 @@ dfn{
 	font-style: italic;
 }
 
+footer{
+	margin-top: 1em;
+	text-align: right;
+}
+
 [epub|type~="z3998:verse"] p,
 [epub|type~="z3998:song"] p{
 	text-align: left;

--- a/src/epub/text/foreword.xhtml
+++ b/src/epub/text/foreword.xhtml
@@ -8,7 +8,11 @@
 	<body epub:type="frontmatter z3998:non-fiction">
 		<section id="foreword" epub:type="foreword z3998:editorial-note">
 			<h2 epub:type="title">Foreword</h2>
-			<p>This edition of Ivan Bunin’s <i epub:type="se:name.publication.book">Short Fiction</i> was produced from various translations. <i epub:type="se:name.publication.short-story">Figures</i> and <i epub:type="se:name.publication.short-story">Elijah, the Prophet</i> were translated by <i epub:type="se:name.publication.journal">The Russian Review</i> and originally published in 1916. <i epub:type="se:name.publication.short-story">The Gentleman from San Francisco</i> was translated by <abbr class="name">D. H.</abbr> Lawrence and <abbr class="name">S. S.</abbr> Koteliansky, and originally published in 1923. <i epub:type="se:name.publication.short-story">Son</i>, <i epub:type="se:name.publication.short-story">Gentle Breathing</i> and <i epub:type="se:name.publication.short-story">Kasimir Stanislavovitch</i> were translated by <abbr class="name">S. S.</abbr> Koteliansky and Leonard Woolf, and originally published in 1923. The other stories were translated by Bernard Guilbert Guerney and originally published in 1923.</p>
+			<p>This edition of Ivan Bunin’s <i epub:type="se:name.publication.book">Short Fiction</i> was produced from various translations. “Figures” and “Elijah, the Prophet” were translated by <i epub:type="se:name.publication.journal">The Russian Review</i> and originally published in 1916. “The Gentleman from San Francisco” was translated by <abbr class="name">D. H.</abbr> Lawrence and <abbr class="name">S. S.</abbr> Koteliansky, and originally published in 1923. “Son”, “Gentle Breathing” and “Kasimir Stanislavovitch” were translated by <abbr class="name">S. S.</abbr> Koteliansky and Leonard Woolf, and originally published in 1923. The other stories were translated by Bernard Guilbert Guerney and originally published in 1923.</p>
+			<footer>
+				<p>Robin Whittleton</p>
+				<p>Malmö, Sweden, 2019</p>
+			</footer>
 		</section>
 	</body>
 </html>


### PR DESCRIPTION
Matches the updated style in https://github.com/standardebooks/leonid-andreyev_short-fiction_herman-bernstein_alexandra-linden_l-a-magnus_k-walter_w-h-lowe_the-rus/pull/2.